### PR TITLE
Step3 implement a simple query

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,17 +2,52 @@ import { makeExecutableSchema } from "@graphql-tools/schema";
 
 const typeDefinitions = /* GraphQL */ `
   type Query {
-    hello: String!
+    info: String!
+    feed: [Link!]!
+  }
+
+  type Link {
+    id: ID!
+    description: String!
+    url: String!
   }
 `;
 
-const resolvers = { Query: { hello: () => "Hello World!" } };
+// 1
+type Link = {
+  id: string;
+  url: string;
+  description: string;
+};
 
-//The GraphQL fragment is starts at the end of line 1 and ends on line 5
-//GraphQL has native types i.e String, Int, ID -> they must use capital letters
-//Information can be found -> https://graphql.org/learn/schema/
+// 2
+const links: Link[] = [
+  {
+    id: "link-0",
+    url: "https://graphql-yoga.com",
+    description: "The easiest way of setting up a GraphQL server",
+  },
+];
+
+const resolvers = {
+  Query: {
+    info: () => `This is the API of a Hackernews Clone`,
+    // 3
+    feed: () => links,
+  },
+  // 4
+  Link: {
+    id: (parent: Link) => parent.id,
+    description: (parent: Link) => parent.description,
+    url: (parent: Link) => parent.url,
+  },
+};
 
 export const schema = makeExecutableSchema({
   resolvers: [resolvers],
   typeDefs: [typeDefinitions],
 });
+
+//The GraphQL fragment is starts at the end of line 1 and ends on line 5
+//GraphQL has native types i.e String, Int, ID -> they must use capital letters
+//Information can be found -> https://graphql.org/learn/schema/


### PR DESCRIPTION
The purpose of this step was to implement a graphQL object type and fields that provide relevant functionality. 

By the end of this section you should be able to run npm start dev or npm run dev, open the yoga GraphQL play ground and be able to successfully query. 


![simpleQuery](https://github.com/michael-west-aligent/microservices-graphQL-Yoga/assets/105182461/813666d5-e6d1-4470-909f-a1a95f1859f5)
