### PR TITLE
step7: create new product mutation

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,3 +1,4 @@
+import { createProductResolver } from "./mutations/createProduct";
 import { postLinkResolver } from "./mutations/post-link";
 import { countriesResolver } from "./queries/countries";
 import { feedResolver } from "./queries/feed";
@@ -12,5 +13,6 @@ export const resolvers = {
 
   Mutation: {
     postLink: postLinkResolver,
+    createProduct: createProductResolver,
   },
 };

--- a/src/resolvers/mutations/createProduct.ts
+++ b/src/resolvers/mutations/createProduct.ts
@@ -1,0 +1,65 @@
+import axios from "axios";
+
+// 1
+interface BcProductArgs {
+  name: string;
+  sku: string;
+  weight: number;
+  price: number;
+  type: "physical" | "digital";
+}
+
+interface BcProductResponse {
+  id: number;
+  name: string;
+  sku: string;
+  weight: number;
+  price: number;
+  type: "physical" | "digital";
+}
+
+interface Product {
+  product_id: string;
+  name: string;
+  sku: string;
+  mass: number;
+  cost: number;
+  type: "physical" | "digital";
+}
+
+// 2
+const headers = {
+  "X-Auth-Token": "2dwb7v48ai89ng29a4miz3dyah2bxi1",
+};
+const STORE_HASH = "xxazhvt7gd";
+
+// 3
+const transformProduct = (bcProduct: BcProductResponse): Product => {
+  const { id, name, sku, price, weight, type } = bcProduct;
+  return {
+    product_id: String(id),
+    name,
+    sku,
+    mass: weight,
+    cost: price,
+    type,
+  };
+};
+
+// 4
+export const createProductResolver = async (
+  _root: unknown,
+  args: BcProductArgs
+) => {
+  // Send user input/args to BC, often this will need to be transformed too
+  const url = `https://api.bigcommerce.com/stores/${STORE_HASH}/v3/catalog/products`;
+  const bcProduct = await axios.post<
+    BcProductArgs,
+    { data: { data: BcProductResponse } }
+  >(url, args, { headers });
+
+  // Transform response from BC to match our schema
+  const transformedProduct = transformProduct(bcProduct.data.data);
+
+  return transformedProduct;
+};

--- a/src/schema/type-definitions.ts
+++ b/src/schema/type-definitions.ts
@@ -7,6 +7,27 @@ export const typeDefinitions = /* GraphQL */ `
 
   type Mutation {
     postLink(url: String!, description: String!): Link!
+    createProduct(
+      name: String!
+      sku: String!
+      weight: Int!
+      price: Int!
+      type: ProductType!
+    ): Product!
+  }
+
+  type Product {
+    product_id: ID!
+    name: String!
+    sku: String!
+    cost: Int!
+    mass: Int!
+    type: ProductType!
+  }
+
+  enum ProductType {
+    physical
+    digital
   }
 
   type Link {


### PR DESCRIPTION
The purpose of this step is to create a new mutation 'create product' which adds your newly created product to Big Commerce Sandbox account. 

![createProduct](https://github.com/michael-west-aligent/microservices-graphQL-Yoga/assets/105182461/f5aeea1a-7d80-4d6c-8347-3e8a9b01e2c4)


The files changed to this are: 
`src/resolvers/index.ts`
`src/schema/type-definitions.ts`

A new file is created: 
`src/resolvers/mutations/createProduct.ts`

Note: If you get a 409 error check the relevant BC Docs, specifically the response types 
https://developer.bigcommerce.com/docs/rest-catalog/products#create-a-product